### PR TITLE
Update version, contributors, and repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "path-to-regexp",
-  "version": "7.2.0",
+  "version": "7.2.0-lineaje-01",
   "description": "Express style path to RegExp utility",
   "keywords": [
     "express",
@@ -10,9 +10,15 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pillarjs/path-to-regexp.git"
+    "url": "https://github.com/lineaje-labs-gos/path-to-regexp"
   },
   "license": "MIT",
+  "contributors": [
+    {
+      "name": "Lineaje DepFixer",
+      "email": "221268890+Lineaje-DepFixer@users.noreply.github.com"
+    }
+  ],
   "exports": "./dist/index.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
- Appended '-lineaje-01' to the version.
- Updated repository URL to point to the new repourl in lineaje-labs-gos
